### PR TITLE
sharness: test executable given by MULTIHASH_BIN if possible

### DIFF
--- a/tests/sharness/lib/test-lib.sh
+++ b/tests/sharness/lib/test-lib.sh
@@ -16,10 +16,21 @@ PATH=$(pwd)/bin:${PATH}
 # to pass through in some cases.
 test "$TEST_VERBOSE" = 1 && verbose=t
 
-# Assert a `multihash` tool is available in the PATH.
-type multihash >/dev/null || {
-	echo >&2 "Cannot find any 'multihash' tool in '$PATH'."
-	echo >&2 "Please make sure 'multihash' is in your PATH."
+# Assert a multihash tool, either given by the MULTIHASH_BIN env
+# variable or called 'multihash', is available.
+if test -n "$MULTIHASH_BIN"
+then
+	echo "Testing '$MULTIHASH_BIN' from MULTIHASH_BIN env variable."
+else
+	echo "Testing 'multihash' as MULTIHASH_BIN env variable is empty."
+	MULTIHASH_BIN="multihash"
+fi
+export MULTIHASH_BIN
+type "$MULTIHASH_BIN" >/dev/null || {
+	echo >&2 "Cannot find '$MULTIHASH_BIN'."
+	echo >&2 "Please make sure it is either:"
+	echo >&2 "  - a path to an executable file, or"
+	echo >&2 "  - the name of an executable file in your PATH ($PATH)."
 	exit 1
 }
 

--- a/tests/sharness/t0010-multihash-basics.sh
+++ b/tests/sharness/t0010-multihash-basics.sh
@@ -8,23 +8,23 @@ test_expect_success "current dir is writable" '
 	echo "It works!" >test.txt
 '
 
-test_expect_success "'multihash --help' looks good" '
-	multihash --help >actual 2>&1 || true &&
+test_expect_success "'$MULTIHASH_BIN --help' looks good" '
+	"$MULTIHASH_BIN" --help >actual 2>&1 || true &&
 	egrep -i "usage" actual >/dev/null
 '
 
 for opt in algorithm check encoding length quiet help
 do 
-	test_expect_success "'multihash --help' mention -$opt option" '
+	test_expect_success "'$MULTIHASH_BIN --help' mention -$opt option" '
 		egrep "[-]$opt" actual >/dev/null
 	'
 done
 
-test_expect_success "'multihash test.txt' works" '
-	multihash test.txt >actual
+test_expect_success "'$MULTIHASH_BIN test.txt' works" '
+	"$MULTIHASH_BIN" test.txt >actual
 '
 
-test_expect_success "'multihash test.txt' output looks good" '
+test_expect_success "'$MULTIHASH_BIN test.txt' output looks good" '
 	echo "QmTwovvskpD1hzuJA8wLA73wjxSisrVknKeNvGZVyjDguU" >expected &&
 	test_cmp expected actual
 '

--- a/tests/sharness/t0020-sha1.sh
+++ b/tests/sharness/t0020-sha1.sh
@@ -14,11 +14,11 @@ test_expect_success "setup sha1 tests" '
 	echo "1114$SHA1" >expected
 '
 
-test_expect_success "'multihash -a=sha1 -e=hex' works" '
-	multihash -a=sha1 -e=hex hash_me.txt >actual
+test_expect_success "'$MULTIHASH_BIN -a=sha1 -e=hex' works" '
+	"$MULTIHASH_BIN" -a=sha1 -e=hex hash_me.txt >actual
 '
 
-test_expect_success "'multihash -a=sha1 -e=hex' output looks good" '
+test_expect_success "'$MULTIHASH_BIN -a=sha1 -e=hex' output looks good" '
 	test_cmp expected actual
 '
 

--- a/tests/sharness/t0030-sha2.sh
+++ b/tests/sharness/t0030-sha2.sh
@@ -16,19 +16,19 @@ test_expect_success "setup sha2 tests" '
 	echo "1340$SHA512" >expected512
 '
 
-test_expect_success "'multihash -a=sha2-256 -e=hex' works" '
-	multihash -a=sha2-256 -e=hex hash_me.txt >actual256
+test_expect_success "'$MULTIHASH_BIN -a=sha2-256 -e=hex' works" '
+	"$MULTIHASH_BIN" -a=sha2-256 -e=hex hash_me.txt >actual256
 '
 
-test_expect_success "'multihash -a=sha2-256 -e=hex' output looks good" '
+test_expect_success "'$MULTIHASH_BIN -a=sha2-256 -e=hex' output looks good" '
 	test_cmp expected256 actual256
 '
 
-test_expect_success "'multihash -a=sha2-512 -e=hex' works" '
-	multihash -a=sha2-512 -e=hex hash_me.txt >actual512
+test_expect_success "'$MULTIHASH_BIN -a=sha2-512 -e=hex' works" '
+	"$MULTIHASH_BIN" -a=sha2-512 -e=hex hash_me.txt >actual512
 '
 
-test_expect_success "'multihash -a=sha2-512 -e=hex' output looks good" '
+test_expect_success "'$MULTIHASH_BIN -a=sha2-512 -e=hex' output looks good" '
 	test_cmp expected512 actual512
 '
 


### PR DESCRIPTION
As suggested in issue #32 (Standard Implementation Test Suite) this makes it easy to change the binary we want to test by setting the MULTIHASH_BIN environment variable.