### PR TITLE
Add MD4,MD5; add warning about obsolete hash functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ They disagree. :(
 
 Warning: **obviously multihash values bias the first two bytes**. Do not expect them to be uniformly distributed. The entropy size is `len(multihash) - 2`. Skip the first two bytes when using them with bloom filters, etc. Why not _ap_pend instead of _pre_pend? Because when reading a stream of hashes, you can know the length of the whole value, and allocate the right amount of memory, skip it, or discard it.
 
+**Obsolete and deprecated hash functions are included** in this list. [MD4](https://en.wikipedia.org/wiki/MD4), [MD5](https://en.wikipedia.org/wiki/MD5) and [SHA-1](https://en.wikipedia.org/wiki/SHA-1) should no longer be used for cryptographic purposes, but since many such hashes already exist they are included in this specification and may be implemented in multihash libraries.
+
 ## Visual Examples
 
 These are visual aids that help tell the story of why Multihash matters.

--- a/hashtable.csv
+++ b/hashtable.csv
@@ -1,5 +1,7 @@
 codec, description, code
 identity,           ,                         0x00
+md4,                ,                         0x04
+md5,                ,                         0x05
 sha1,               ,                         0x11
 sha2-256,           ,                         0x12
 sha2-512,           ,                         0x13

--- a/hashtable.csv
+++ b/hashtable.csv
@@ -1,8 +1,8 @@
 ,, Note: all values are defined in multiformats/multicodecs
 codec, description, code
 identity,           ,                         0x00
-md4,                ,                         0xd3
-md5,                ,                         0xd4
+md4,                ,                         0xd4
+md5,                ,                         0xd5
 sha1,               ,                         0x11
 sha2-256,           ,                         0x12
 sha2-512,           ,                         0x13

--- a/hashtable.csv
+++ b/hashtable.csv
@@ -1,7 +1,8 @@
+,, Note: all values are defined in multiformats/multicodecs
 codec, description, code
 identity,           ,                         0x00
-md4,                ,                         0x04
-md5,                ,                         0x05
+md4,                ,                         0xd3
+md5,                ,                         0xd4
 sha1,               ,                         0x11
 sha2-256,           ,                         0x12
 sha2-512,           ,                         0x13


### PR DESCRIPTION
Resolves #71 by adding MD4 and MD5 to the list of supported hash functions.

Adds a note to the README cautioning about their use.