### PR TITLE
Recommend `pymultihash` instead of the defunct `python-multihash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Yes, but we already have to agree on functions, so this is not hard. The table e
   - [by @multiformats](//github.com/multiformats/rust-multihash)
   - [by @google](//github.com/google/rust-multihash)
 - [haskell-multihash](//github.com/LukeHoersten/multihash)
-- [python-multihash](//github.com/tehmaze/python-multihash)
+- [pymultihash](//github.com/ivilata/pymultihash)
 - [elixir-multihash](//github.com/zabirauf/ex_multihash), [elixir-multihashing](//github.com/candeira/ex_multihashing)
 - [swift-multihash](//github.com/NeoTeo/SwiftMultihash)
 - [ruby-multihash](//github.com/neocities/ruby-multihash)


### PR DESCRIPTION
The repo of the currently recommend multihash implementation doesn't even exist anymore. @ivilata's implementation of multihash on-the-other hand is quite feature-complete, comes with good documentation and [was positively received by previous `py-ipfs` developers](https://github.com/ipfs/py-ipfs/issues/23#issuecomment-182133730). The heavy-lifting is done by Python's built-in `hashlib` module that python developers are already familiar with. Hence I believe this should become the recommended implementation for python. If @ivilata isn't opposed to it, I believe it should also be moved to the organization (as https://github.com/multiformats/py-multihash).