### PR TITLE
Add copper multicodec/multihash

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Yes, but we already have to agree on functions, so this is not hard. The table e
   - [js-multihash](//github.com/multiformats/js-multihash) (archived)
 - java-multihash
   - [multiformats/java-multihash](//github.com/multiformats/java-multihash)
+  - [copper multicodec and multihash](https://github.com/filip26/copper-multicodec)
   - [comodal/hash-overlay](//github.com/comodal/hash-overlay)
 - kotlin-multihash
   - [kotlin-multihash](//github.com/changjiashuai/kotlin-multihash)


### PR DESCRIPTION
Hi,
please add copper-multicodec. It is up-to-date and includes generic support for Multihash encode/decode. I've placed copper before `comodal/hash-overlay`  - the project seems gone [404]. 

Thank you!