### PR TITLE
Remove 404 Java library from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Yes, but we already have to agree on functions, so this is not hard. The table e
 - java-multihash
   - [multiformats/java-multihash](//github.com/multiformats/java-multihash)
   - [copper multicodec and multihash](https://github.com/filip26/copper-multicodec)
-  - [comodal/hash-overlay](//github.com/comodal/hash-overlay)
 - kotlin-multihash
   - [kotlin-multihash](//github.com/changjiashuai/kotlin-multihash)
   - [multiformat](https://github.com/erwin-kok/multiformat)


### PR DESCRIPTION
https://github.com/comodal/hash-overlay seems to have disappeared.